### PR TITLE
When variable undefined use default "" resp. 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Implementation of BASIC interpreter in Rust. The implementation follows the [ECM
 
 This project is **WIP**:
 
-![test coverage](https://img.shields.io/badge/style-30%2F212%20tests-blue.svg?longCache=true&label=Minimal%20basic%20test%20coverage)
+![test coverage](https://img.shields.io/badge/style-31%2F212%20tests-blue.svg?longCache=true&label=Minimal%20basic%20test%20coverage)
 
 1. Pick any tests marked with `try_test_program` in [tests/integration.rs](tests/integration.rs).
 2. Change the test to use the `test_program` macro.

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,8 +16,6 @@ pub enum Error {
         src_line_number: u16,
     },
     InvalidTabCall,
-    UndefinedNumericVariable(NumericVariable),
-    UndefinedStringVariable(StringVariable),
     DuplicateLineNumber {
         line_number: u16,
     },
@@ -53,12 +51,6 @@ impl fmt::Display for Error {
                 src_line_number
             ),
             Error::InvalidTabCall => write!(f, "error: invalid TAB call"),
-            Error::UndefinedNumericVariable(ref variable) => {
-                write!(f, "error: undefined numeric variable '{}'", variable)
-            }
-            Error::UndefinedStringVariable(ref variable) => {
-                write!(f, "error: undefined string variable '{}'", variable)
-            }
             Error::DuplicateLineNumber { line_number } => {
                 write!(f, "error: duplicate line number {}", line_number)
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -15,11 +15,7 @@ struct State {
 }
 
 fn evaluate_numeric_variable(variable: &NumericVariable, state: &State) -> Result<f64, Error> {
-    state
-        .numeric_values
-        .get(variable)
-        .cloned()
-        .ok_or_else(|| Error::UndefinedNumericVariable(*variable))
+    Ok(state.numeric_values.get(variable).cloned().unwrap_or(0f64))
 }
 
 fn evaluate_primary(primary: &Primary, state: &State) -> Result<f64, Error> {
@@ -156,7 +152,8 @@ fn evaluate_string_expression<'a>(
             let value = state
                 .string_values
                 .get(variable)
-                .ok_or_else(|| Error::UndefinedStringVariable(*variable))?;
+                .map(|s| -> &str { s })
+                .unwrap_or("");
             Ok(value)
         }
         StringExpression::Constant(constant) => Ok(&constant.0),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -15,7 +15,7 @@ struct State {
 }
 
 fn evaluate_numeric_variable(variable: &NumericVariable, state: &State) -> Result<f64, Error> {
-    Ok(state.numeric_values.get(variable).cloned().unwrap_or(0f64))
+    Ok(state.numeric_values.get(variable).cloned().unwrap_or(0.0))
 }
 
 fn evaluate_primary(primary: &Primary, state: &State) -> Result<f64, Error> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -92,7 +92,7 @@ test_program!(P019);
 test_program!(P020);
 test_program!(P021);
 test_program!(P022);
-try_test_program!(P023);
+test_program!(P023);
 test_program!(P024);
 test_program!(P025);
 try_test_program!(P026);


### PR DESCRIPTION
Apparently, this is according to ANSI spec. There is nothing about
this in ECMA spec. Since I don't have access to ANSI, I believe
the test.