### PR TITLE
Replace trim_right_matches by trim_end_matches

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -42,7 +42,7 @@ pub fn format_float(value: f64) -> String {
         let integ = parts.next().unwrap();
         let fract = parts.next().unwrap();
 
-        let fract = fract.trim_right_matches('0');
+        let fract = fract.trim_end_matches('0');
 
         let extrad_int: i64 = str::parse(extrad).unwrap();
         if extrad_int > 0


### PR DESCRIPTION
I was building with `nightly` and turns out this function will be deprecated in favor of `trim_end_matches` in 1.33.